### PR TITLE
Optimizations

### DIFF
--- a/swarmz.h
+++ b/swarmz.h
@@ -55,7 +55,7 @@ namespace sw {
         }
 
         float Length() const {
-			return std::sqrtf(std::powf(X, 2) + std::powf(Y, 2) + std::powf(Z, 2));
+            return std::sqrtf(std::powf(X, 2) + std::powf(Y, 2) + std::powf(Z, 2));
         }
 
         float DotProduct(const Vec3 &v) const {
@@ -180,7 +180,7 @@ namespace sw {
         }
 
         void Update(float delta) {
-			BlindspotAngleDegCompareValue = cosf(PI2 * BlindspotAngleDeg / 360.0f);
+            BlindspotAngleDegCompareValue = cosf(PI2 * BlindspotAngleDeg / 360.0f);
             UpdateAcceleration();
 
             for (auto &b : *boids) {
@@ -203,14 +203,14 @@ namespace sw {
         std::vector<Boid> *boids;
         std::unordered_map<Vec3, std::vector<Boid *>, Vec3Hasher> voxelCache;
         std::mt19937 eng;
-		float BlindspotAngleDegCompareValue = 0; // = cos(PI2 * BlindspotAngleDeg / 360)
+        float BlindspotAngleDegCompareValue = 0; // = cos(PI2 * BlindspotAngleDeg / 360)
 
         struct NearbyBoidsInformation
         {
-			Vec3 separationSum;
-			Vec3 headingSum;
-			Vec3 positionSum;
-			int count;
+            Vec3 separationSum;
+            Vec3 headingSum;
+            Vec3 positionSum;
+            int count;
         };
 
         void updateBoid(Boid &b) {
@@ -267,7 +267,7 @@ namespace sw {
 
         std::vector<NearbyBoid> getNearbyBoids(const Boid &b) const {
             std::vector<NearbyBoid> result;
-			result.reserve(boids->size());
+            result.reserve(boids->size());
 
             Vec3 voxelPos = getVoxelForBoid(b);
             voxelPos.X -= 1;
@@ -297,12 +297,12 @@ namespace sw {
                     Vec3 vec = p2 - p1;
                     float distance = vec.Length();
 
-					float compareValue = 0;
-					float l1 = vec.Length();
-					float l2 = b.Velocity.Length();
-					if (l1 != 0 && l2 != 0) {
-						compareValue = b.Velocity.Negative().DotProduct(vec) / (l1 * l2);
-					}
+                    float compareValue = 0;
+                    float l1 = vec.Length();
+                    float l2 = b.Velocity.Length();
+                    if (l1 != 0 && l2 != 0) {
+                        compareValue = b.Velocity.Negative().DotProduct(vec) / (l1 * l2);
+                    }
 
                     if ((&b) != test && distance <= PerceptionRadius && (BlindspotAngleDegCompareValue > compareValue || b.Velocity.Length() == 0)) {
                         NearbyBoid nb;

--- a/swarmz.h
+++ b/swarmz.h
@@ -145,7 +145,6 @@ namespace sw {
         Vec3 Position;
         Vec3 Velocity;
         Vec3 Acceleration;
-		int neighbours;
 
         explicit Boid(Vec3 pos, Vec3 vel) : Position(pos), Velocity(vel) {
         }
@@ -221,7 +220,6 @@ namespace sw {
             Vec3 po = b.Position;
 
             auto nearby = getNearbyBoids(b);
-			b.neighbours = nearby.size();
 
             for (NearbyBoid &closeBoid : nearby) {
                 if (closeBoid.distance == 0) {


### PR DESCRIPTION
For a university course, I optimized the Swarmz library. Here is a maintainable version of my optimized Swarmz.h, including:

- Removed unnecessary voxel checks (it used to check a volume of 4x4x4 voxels instead of the necessary 3x3x3)
- I eliminated the need for acos operations, which took up a large amount of computation time calculating blindAngle. But we don't need the exact value, we only need to compare it to another value. I added a new variable BlindspotAngleDegCompareValue which is updated each frame and eliminates the expensive acos(..) operation.
- In getNearbyBoids, I reserved some space in the result vector, which increases performance.

In my test setup, this improved the frame time from 224 to 58 ms for 5000 boids. If you are interested, I have optimized the program much further to about 12 ms per frame (single core) for the same setup. However, this code is quite a bit harder to read and has less hardware support due to the heavy usage of AVX instructions.